### PR TITLE
feat: wheels for macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os:
+          - macos-11
+          - ubuntu-20.04
+          - windows-2022
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
With any luck, just running the cibuildwheel step on other platforms than just Ubuntu should be enough...

⚠️ I didn't test this yet, since I didn't want to yet try and wrangle the workflow to running the wheeling step for non-`main` refs...