### PR TITLE
chore: add test_non_uppercase_b32_data

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -366,6 +366,6 @@ def _ulid_timestamp(ulid: str) -> int:
 
 def test_non_uppercase_b32_data():
     assert (
-        ulid_transform.ulid_to_bytes("not_uppercase_b32_data_:::")
+        ulid_to_bytes("not_uppercase_b32_data_:::")
         == b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x8c\xff\xff\xff\xff\xff\xff"
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -362,3 +362,10 @@ def _ulid_timestamp(ulid: str) -> int:
         ),
         byteorder="big",
     )
+
+
+def test_non_uppercase_b32_data():
+    assert (
+        ulid_transform.ulid_to_bytes("not_uppercase_b32_data_:::")
+        == b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x8c\xff\xff\xff\xff\xff\xff"
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -365,7 +365,4 @@ def _ulid_timestamp(ulid: str) -> int:
 
 
 def test_non_uppercase_b32_data():
-    assert (
-        ulid_to_bytes("not_uppercase_b32_data_:::")
-        == b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x8c\xff\xff\xff\xff\xff\xff"
-    )
+    assert len(ulid_to_bytes("not_uppercase_b32_data_:::")) == 16


### PR DESCRIPTION
As suggested in https://github.com/basnijholt/adaptive-lighting/issues/493#issuecomment-1499618994 to keep future compatibility with packages using `ulid-transform` with non-compliant ids, such as https://github.com/basnijholt/adaptive-lighting.