### PR TITLE
fix: missing decode for _bytes_to_ulid

### DIFF
--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str).encode("ascii")
+    return _cpp_ulid_to_bytes(ulid_str)
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -22,9 +22,9 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str.encode('ascii'))
+    return _cpp_ulid_to_bytes(ulid_str.encode("ascii"))
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:
         raise ValueError(f"ULID bytes be 16 bytes: {ulid_bytes}")
-    return _cpp_bytes_to_ulid(ulid_bytes).decode('ascii')
+    return _cpp_bytes_to_ulid(ulid_bytes).decode("ascii")

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -27,4 +27,4 @@ def _ulid_to_bytes(ulid_str: str) -> bytes:
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:
         raise ValueError(f"ULID bytes be 16 bytes: {ulid_bytes}")
-    return _cpp_bytes_to_ulid(ulid_bytes)
+    return _cpp_bytes_to_ulid(ulid_bytes).decode('ascii')

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -8,7 +8,7 @@ import cython
 
 cdef extern from "ulid_wrapper.h":
     string _cpp_ulid_at_time(double timestamp)
-    string _cpp_ulid_to_bytes(string ulid)
+    string _cpp_ulid_to_bytes(const char * ulid_string)
     string _cpp_ulid()
     string _cpp_bytes_to_ulid(string ulid_bytes)
 
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str.encode("ascii"))
+    return _cpp_ulid_to_bytes(ulid_str)
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -8,7 +8,7 @@ import cython
 
 cdef extern from "ulid_wrapper.h":
     string _cpp_ulid_at_time(double timestamp)
-    const char * _cpp_ulid_to_bytes(const char * ulid_string)
+    string _cpp_ulid_to_bytes(const char * ulid_string)
     string _cpp_ulid()
     string _cpp_bytes_to_ulid(string ulid_bytes)
 
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str)
+    return _cpp_ulid_to_bytes(ulid_str).encode("ascii")
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str)
+    return _cpp_ulid_to_bytes(ulid_str).encode("ascii")
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -8,7 +8,7 @@ import cython
 
 cdef extern from "ulid_wrapper.h":
     string _cpp_ulid_at_time(double timestamp)
-    string _cpp_ulid_to_bytes(const char * ulid_string)
+    const char * _cpp_ulid_to_bytes(const char * ulid_string)
     string _cpp_ulid()
     string _cpp_bytes_to_ulid(string ulid_bytes)
 
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str).encode("ascii")
+    return _cpp_ulid_to_bytes(ulid_str)
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str)
+    return _cpp_ulid_to_bytes(ulid_str).encode('ascii')
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -22,7 +22,7 @@ def _ulid_at_time(_time: float) -> str:
 def _ulid_to_bytes(ulid_str: str) -> bytes:
     if len(ulid_str) != 26:
         raise ValueError(f"ULID must be a 26 character string: {ulid_str}")
-    return _cpp_ulid_to_bytes(ulid_str).encode('ascii')
+    return _cpp_ulid_to_bytes(ulid_str.encode('ascii'))
 
 def _bytes_to_ulid(ulid_bytes: bytes) -> str:
     if len(ulid_bytes) != 16:

--- a/src/ulid_transform/ulid_impl.py
+++ b/src/ulid_transform/ulid_impl.py
@@ -411,17 +411,17 @@ def bytes_to_ulid(value: bytes) -> str:
 
 
 try:
-    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401
+    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
         _bytes_to_ulid as bytes_to_ulid,
     )
-    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401
+    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
         _ulid_at_time as ulid_at_time,
     )
-    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401
+    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
         _ulid_now as ulid_now,
     )
-    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401
+    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
         _ulid_to_bytes as ulid_to_bytes,
     )
-except ImportError:
-    pass
+except ImportError:  # pragma: no cover
+    pass  # pragma: no cover

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -17,9 +17,9 @@ std::string _cpp_ulid_at_time(double epoch_time) {
   return ulid::Marshal(ulid);
 }
 
-std::string _cpp_ulid_to_bytes(std::string ulid_string) {
+std::string _cpp_ulid_to_bytes(const char * ulid_string) {
   ulid::ULID ulid;
-  ulid::UnmarshalFrom(ulid_string.c_str(), ulid);
+  ulid::UnmarshalFrom(ulid_string, ulid);
   std::vector<uint8_t> data = ulid::MarshalBinary(ulid);
   std::string str(reinterpret_cast<char *>(data.data()), data.size());
   return str;

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -17,12 +17,12 @@ std::string _cpp_ulid_at_time(double epoch_time) {
   return ulid::Marshal(ulid);
 }
 
-const char * _cpp_ulid_to_bytes(const char * ulid_string) {
+std::string _cpp_ulid_to_bytes(const char * ulid_string) {
   ulid::ULID ulid;
   ulid::UnmarshalFrom(ulid_string, ulid);
   std::vector<uint8_t> data = ulid::MarshalBinary(ulid);
   std::string str(reinterpret_cast<char *>(data.data()), data.size());
-  return str.c_str();
+  return str;
 }
 
 std::string _cpp_bytes_to_ulid(std::string bytes_string) {

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -17,12 +17,12 @@ std::string _cpp_ulid_at_time(double epoch_time) {
   return ulid::Marshal(ulid);
 }
 
-std::string _cpp_ulid_to_bytes(const char * ulid_string) {
+const char * _cpp_ulid_to_bytes(const char * ulid_string) {
   ulid::ULID ulid;
   ulid::UnmarshalFrom(ulid_string, ulid);
   std::vector<uint8_t> data = ulid::MarshalBinary(ulid);
   std::string str(reinterpret_cast<char *>(data.data()), data.size());
-  return str;
+  return str.c_str();
 }
 
 std::string _cpp_bytes_to_ulid(std::string bytes_string) {

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -5,7 +5,7 @@
 
 std::string _cpp_ulid();
 std::string _cpp_ulid_at_time(double timestamp);
-const char * _cpp_ulid_to_bytes(const char * ulid_string);
+std::string _cpp_ulid_to_bytes(const char * ulid_string);
 std::string _cpp_bytes_to_ulid(std::string bytes_string);
 
 #endif

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -5,7 +5,7 @@
 
 std::string _cpp_ulid();
 std::string _cpp_ulid_at_time(double timestamp);
-std::string _cpp_ulid_to_bytes(const char * ulid_string);
+const char * _cpp_ulid_to_bytes(const char * ulid_string);
 std::string _cpp_bytes_to_ulid(std::string bytes_string);
 
 #endif

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -5,7 +5,7 @@
 
 std::string _cpp_ulid();
 std::string _cpp_ulid_at_time(double timestamp);
-std::string _cpp_ulid_to_bytes(std::string ulid_string);
+std::string _cpp_ulid_to_bytes(const char * ulid_string);
 std::string _cpp_bytes_to_ulid(std::string bytes_string);
 
 #endif

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,6 +29,16 @@ def test_ulid_to_bytes():
     )
 
 
+def test_ulid_to_bytes_overflow():
+    with pytest.raises(ValueError):
+        ulid_to_bytes("01GTCKZT7K26YEVVW6AMQ3J0VT0000")
+
+
+def test_ulid_to_bytes_under_low():
+    with pytest.raises(ValueError):
+        ulid_to_bytes("01")
+
+
 def test_bytes_to_ulid():
     assert (
         bytes_to_ulid(b"\x01\x86\x99?\xe8\xf3\x11\xbc\xed\xef\x86U.9\x03z")


### PR DESCRIPTION
fixes  `src/ulid_transform/_ulid_impl.pyx:30:29: default encoding required for conversion from 'string' to 'unicode object'`