### PR TITLE
feat: add fast ULID bytes functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Generated Cython file
+src/ulid_transform/*.cpp

--- a/src/ulid_transform/__init__.py
+++ b/src/ulid_transform/__init__.py
@@ -4,18 +4,22 @@ from .ulid_impl import (
     bytes_to_ulid,
     bytes_to_ulid_or_none,
     ulid_at_time,
+    ulid_at_time_bytes,
     ulid_hex,
     ulid_now,
+    ulid_now_bytes,
     ulid_to_bytes,
     ulid_to_bytes_or_none,
 )
 
 __all__ = [
-    "ulid_now",
-    "ulid_at_time",
-    "ulid_hex",
-    "ulid_to_bytes",
     "bytes_to_ulid",
-    "ulid_to_bytes_or_none",
     "bytes_to_ulid_or_none",
+    "ulid_at_time",
+    "ulid_at_time_bytes",
+    "ulid_hex",
+    "ulid_now",
+    "ulid_now_bytes",
+    "ulid_to_bytes",
+    "ulid_to_bytes_or_none",
 ]

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -1,18 +1,23 @@
 # distutils: language = c++
 from libcpp.string cimport string
+from libcpp.vector cimport vector
 
-from time import time
 from typing import Optional
-
-import cython
 
 
 cdef extern from "ulid_wrapper.h":
     string _cpp_ulid_at_time(double timestamp)
+    vector[unsigned char] _cpp_ulid_at_time_bytes(double timestamp)
     string _cpp_ulid_to_bytes(const char * ulid_string)
     string _cpp_ulid()
+    vector[unsigned char] _cpp_ulid_bytes()
     string _cpp_bytes_to_ulid(string ulid_bytes)
 
+def _ulid_now_bytes() -> bytes:
+    return bytes(_cpp_ulid_bytes())
+
+def _ulid_at_time_bytes(_time: float) -> bytes:
+    return bytes(_cpp_ulid_at_time_bytes(_time))
 
 def _ulid_now() -> str:
     return _cpp_ulid().decode("ascii")

--- a/src/ulid_transform/ulid_impl.py
+++ b/src/ulid_transform/ulid_impl.py
@@ -280,6 +280,21 @@ def ulid_hex() -> str:
     return f"{int(time()*1000):012x}{getrandbits(80):020x}"
 
 
+def ulid_at_time_bytes(timestamp: float) -> bytes:
+    """Generate an ULID as 16 bytes that will work for a UUID.
+
+    uuid.UUID(bytes=ulid_bytes)
+    """
+    return int(timestamp * 1000).to_bytes(6, byteorder="big") + int(
+        getrandbits(80)
+    ).to_bytes(10, byteorder="big")
+
+
+def ulid_now_bytes() -> bytes:
+    """Generate an ULID as 16 bytes that will work for a UUID."""
+    return ulid_at_time_bytes(time())
+
+
 def ulid_now() -> str:
     """Generate a ULID."""
     return ulid_at_time(time())
@@ -302,10 +317,7 @@ def ulid_at_time(timestamp: float) -> str:
     import ulid
     ulid.parse(ulid_util.ulid())
     """
-    return _encode(
-        int((timestamp) * 1000).to_bytes(6, byteorder="big")
-        + int(getrandbits(80)).to_bytes(10, byteorder="big")
-    )
+    return _encode(ulid_at_time_bytes(timestamp))
 
 
 def _encode(ulid_bytes: bytes) -> str:
@@ -441,7 +453,13 @@ try:
         _ulid_at_time as ulid_at_time,
     )
     from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
+        _ulid_at_time_bytes as ulid_at_time_bytes,
+    )
+    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
         _ulid_now as ulid_now,
+    )
+    from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
+        _ulid_now_bytes as ulid_now_bytes,
     )
     from ._ulid_impl import (  # type: ignore[no-redef] # noqa: F811 F401 # pragma: no cover
         _ulid_to_bytes as ulid_to_bytes,

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -10,11 +10,25 @@ std::string _cpp_ulid() {
   return ulid::Marshal(ulid);
 }
 
+std::vector<uint8_t> _cpp_ulid_bytes() {
+  ulid::ULID ulid;
+  ulid::EncodeTimeSystemClockNow(ulid);
+  ulid::EncodeEntropyRand(ulid);
+  return ulid::MarshalBinary(ulid);
+}
+
 std::string _cpp_ulid_at_time(double epoch_time) {
   ulid::ULID ulid;
   ulid::EncodeTimestamp(static_cast<int64_t>(epoch_time*1000), ulid);
   ulid::EncodeEntropyRand(ulid);
   return ulid::Marshal(ulid);
+}
+
+std::vector<uint8_t> _cpp_ulid_at_time_bytes(double epoch_time) {
+  ulid::ULID ulid;
+  ulid::EncodeTimestamp(static_cast<int64_t>(epoch_time*1000), ulid);
+  ulid::EncodeEntropyRand(ulid);
+  return ulid::MarshalBinary(ulid);
 }
 
 std::string _cpp_ulid_to_bytes(const char * ulid_string) {

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -4,7 +4,9 @@
 #define ULID_WRAPPER_H
 
 std::string _cpp_ulid();
+std::vector<uint8_t> _cpp_ulid_bytes();
 std::string _cpp_ulid_at_time(double timestamp);
+std::vector<uint8_t> _cpp_ulid_at_time_bytes(double timestamp);
 std::string _cpp_ulid_to_bytes(const char * ulid_string);
 std::string _cpp_bytes_to_ulid(std::string bytes_string);
 


### PR DESCRIPTION
This PR adds fast ULID-as-bytes functions, for applications where it's necessary to quickly generate ULIDs as Python `uuid.UUID`s.

Benchmarks using `pytest-benchmark` (separate PR upcoming for those):

```
------------------- benchmark: 4 tests ------------------
Name (time in ns)                  OPS (Kops/s)
---------------------------------------------------------
test_ut_ulid_now_bytes[cython]       1,338.4093 (1.0)
test_ut_ulid_hex[py]                   994.9143 (0.74)
test_ulid2_uuid[py]                    899.7792 (0.67)
test_ulidpy_uuid[py]                   733.9955 (0.55)
---------------------------------------------------------
```

There's also a follow-up avenue to make all of the Cython operations a little faster and less allocatey, but that's out of scope for this PR.