### PR TITLE
feat: improve performance of C implementation

### DIFF
--- a/bench/test_timestamp.py
+++ b/bench/test_timestamp.py
@@ -1,0 +1,29 @@
+import pytest
+
+import tests.conftest  # noqa
+
+example = "01J3YPYJJW00GW0X476W5TVBFE"
+example_timestamp = 1722238847580
+
+
+@pytest.mark.benchmark(group="timestamp")
+def test_ut_timestamp(benchmark, impl):
+    assert benchmark(lambda: impl.ulid_to_timestamp(example)) == example_timestamp
+
+
+@pytest.mark.benchmark(group="timestamp")
+def test_ulid2_timestamp(benchmark):
+    ulid2 = pytest.importorskip("ulid2")
+    assert (
+        benchmark(lambda: ulid2.get_ulid_timestamp(example))
+        == example_timestamp / 1000.0
+    )
+
+
+@pytest.mark.benchmark(group="timestamp")
+def test_ulidpy_uuid(benchmark):
+    ulid = pytest.importorskip("ulid")
+    assert (
+        benchmark(lambda: ulid.from_str(example).timestamp().timestamp)
+        == example_timestamp / 1000.0
+    )

--- a/src/ulid_transform/__init__.py
+++ b/src/ulid_transform/__init__.py
@@ -11,6 +11,7 @@ try:
         ulid_now_bytes,
         ulid_to_bytes,
         ulid_to_bytes_or_none,
+        ulid_to_timestamp,
     )
 except ImportError:
     from ._py_ulid_impl import (
@@ -23,6 +24,7 @@ except ImportError:
         ulid_now_bytes,
         ulid_to_bytes,
         ulid_to_bytes_or_none,
+        ulid_to_timestamp,
     )
 
 __all__ = [
@@ -35,4 +37,5 @@ __all__ = [
     "ulid_now_bytes",
     "ulid_to_bytes",
     "ulid_to_bytes_or_none",
+    "ulid_to_timestamp",
 ]

--- a/src/ulid_transform/_py_ulid_impl.py
+++ b/src/ulid_transform/_py_ulid_impl.py
@@ -440,3 +440,15 @@ def bytes_to_ulid_or_none(ulid_bytes: bytes | None) -> str | None:
         return bytes_to_ulid(ulid_bytes)
     except ValueError:
         return None
+
+
+def ulid_to_timestamp(ulid: str | bytes) -> int:
+    """
+    Get the timestamp from a ULID.
+    The returned value is in milliseconds since the UNIX epoch.
+    """
+    if not isinstance(ulid, bytes):
+        ulid_bytes = ulid_to_bytes(ulid)
+    else:
+        ulid_bytes = ulid
+    return int.from_bytes(b"\x00\x00" + ulid_bytes[:6], "big")

--- a/src/ulid_transform/_ulid_impl.pyx
+++ b/src/ulid_transform/_ulid_impl.pyx
@@ -1,15 +1,22 @@
 # distutils: language = c++
-from libcpp.string cimport string
-from libcpp.vector cimport vector
+# cython: language_level=3, c_string_type=str, c_string_encoding=ascii
+
+# The `<bytes>xxx[:N]` syntax is required for two reasons:
+# 1. When working with "ULID bytes", the buffer may contain NULs.
+# 2. When working with ULID text, the buffer is exactly 26 bytes long and not NUL-terminated.
+# See https://github.com/cython/cython/issues/3234
+
+from libc.stdint cimport uint8_t
 
 
 cdef extern from "ulid_wrapper.h":
-    string _cpp_ulid_at_time(double timestamp)
-    vector[unsigned char] _cpp_ulid_at_time_bytes(double timestamp)
-    string _cpp_ulid_to_bytes(const char * ulid_string)
-    string _cpp_ulid()
-    vector[unsigned char] _cpp_ulid_bytes()
-    string _cpp_bytes_to_ulid(string ulid_bytes)
+    void _cpp_ulid(char dst[26]) nogil
+    void _cpp_ulid_bytes(uint8_t dst[16]) nogil
+    void _cpp_ulid_at_time(double epoch_time, char dst[26]) nogil
+    void _cpp_ulid_at_time_bytes(double epoch_time, uint8_t dst[16]) nogil
+    void _cpp_ulid_to_bytes(const char ulid_string[26], uint8_t dst[16]) nogil
+    void _cpp_bytes_to_ulid(const uint8_t b[16], char * dst) nogil
+    void _cpp_hexlify_16(const uint8_t b[16], char dst[32]) nogil
 
 
 def ulid_hex() -> str:
@@ -22,12 +29,18 @@ def ulid_hex() -> str:
 
     ulid.from_uuid(uuid.UUID(ulid_hex))
     """
-    return bytes(_cpp_ulid_bytes()).hex()
+    cdef unsigned char ulid_bytes_buf[16]
+    _cpp_ulid_bytes(ulid_bytes_buf)
+    cdef char ulid_hex_buf[32]
+    _cpp_hexlify_16(ulid_bytes_buf, ulid_hex_buf)
+    return <str>ulid_hex_buf[:32]
 
 
 def ulid_now_bytes() -> bytes:
     """Generate an ULID as 16 bytes that will work for a UUID."""
-    return bytes(_cpp_ulid_bytes())
+    cdef unsigned char ulid_bytes_buf[16]
+    _cpp_ulid_bytes(ulid_bytes_buf)
+    return <bytes>ulid_bytes_buf[:16]
 
 
 def ulid_at_time_bytes(timestamp: float) -> bytes:
@@ -35,12 +48,16 @@ def ulid_at_time_bytes(timestamp: float) -> bytes:
 
     uuid.UUID(bytes=ulid_bytes)
     """
-    return bytes(_cpp_ulid_at_time_bytes(timestamp))
+    cdef unsigned char ulid_bytes_buf[16]
+    _cpp_ulid_at_time_bytes(timestamp, ulid_bytes_buf)
+    return <bytes>ulid_bytes_buf[:16]
 
 
 def ulid_now() -> str:
     """Generate a ULID."""
-    return _cpp_ulid().decode("ascii")
+    cdef char ulid_text_buf[26]
+    _cpp_ulid(ulid_text_buf)
+    return <str>ulid_text_buf[:26]
 
 
 def ulid_at_time(timestamp: float) -> str:
@@ -60,32 +77,42 @@ def ulid_at_time(timestamp: float) -> str:
     import ulid
     ulid.parse(ulid_util.ulid())
     """
-    return _cpp_ulid_at_time(timestamp).decode("ascii")
+    cdef char ulid_text_buf[26]
+    _cpp_ulid_at_time(timestamp, ulid_text_buf)
+    return <str>ulid_text_buf[:26]
 
 
 def ulid_to_bytes(value: str) -> bytes:
     """Decode a ulid to bytes."""
     if len(value) != 26:
         raise ValueError(f"ULID must be a 26 character string: {value}")
-    return _cpp_ulid_to_bytes(value.encode("ascii"))
+    cdef unsigned char ulid_bytes_buf[16]
+    _cpp_ulid_to_bytes(value, ulid_bytes_buf)
+    return <bytes>ulid_bytes_buf[:16]
 
 
 def bytes_to_ulid(value: bytes) -> str:
     """Encode bytes to a ulid."""
     if len(value) != 16:
         raise ValueError(f"ULID bytes must be 16 bytes: {value!r}")
-    return _cpp_bytes_to_ulid(value).decode("ascii")
+    cdef char ulid_text_buf[26]
+    _cpp_bytes_to_ulid(value, ulid_text_buf)
+    return <str>ulid_text_buf[:26]
 
 
 def ulid_to_bytes_or_none(ulid: str | None) -> bytes | None:
     """Convert an ulid to bytes."""
     if ulid is None or len(ulid) != 26:
         return None
-    return _cpp_ulid_to_bytes(ulid.encode("ascii"))
+    cdef unsigned char ulid_bytes_buf[16]
+    _cpp_ulid_to_bytes(ulid, ulid_bytes_buf)
+    return <bytes>ulid_bytes_buf[:16]
 
 
 def bytes_to_ulid_or_none(ulid_bytes: bytes | None) -> str | None:
     """Convert bytes to a ulid."""
     if ulid_bytes is None or len(ulid_bytes) != 16:
         return None
-    return _cpp_bytes_to_ulid(ulid_bytes).decode("ascii")
+    cdef char ulid_text_buf[26]
+    _cpp_bytes_to_ulid(ulid_bytes, ulid_text_buf)
+    return <str>ulid_text_buf[:26]

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -1,46 +1,80 @@
 #include "ulid_wrapper.h"
 #include "ulid.hh"
 
-using namespace std;
-
-std::string _cpp_ulid() {
+/**
+* Generate a new text ULID and write it to the provided buffer.
+* The buffer is NOT null-terminated.
+*/
+void _cpp_ulid(char dst[26]) {
   ulid::ULID ulid;
   ulid::EncodeTimeSystemClockNow(ulid);
   ulid::EncodeEntropyRand(ulid);
-  return ulid::Marshal(ulid);
+  ulid::MarshalTo(ulid, dst);
 }
 
-std::vector<uint8_t> _cpp_ulid_bytes() {
+/**
+* Generate a new binary ULID and write it to the provided buffer.
+*/
+void _cpp_ulid_bytes(uint8_t dst[16]) {
   ulid::ULID ulid;
   ulid::EncodeTimeSystemClockNow(ulid);
   ulid::EncodeEntropyRand(ulid);
-  return ulid::MarshalBinary(ulid);
+  ulid::MarshalBinaryTo(ulid, dst);
 }
 
-std::string _cpp_ulid_at_time(double epoch_time) {
+/**
+* Generate a new text ULID at the provided epoch time and write it to the provided buffer.
+* The buffer is NOT null-terminated.
+*/
+void _cpp_ulid_at_time(double epoch_time, char dst[26]) {
   ulid::ULID ulid;
   ulid::EncodeTimestamp(static_cast<int64_t>(epoch_time*1000), ulid);
   ulid::EncodeEntropyRand(ulid);
-  return ulid::Marshal(ulid);
+  ulid::MarshalTo(ulid, dst);
 }
 
-std::vector<uint8_t> _cpp_ulid_at_time_bytes(double epoch_time) {
+/**
+* Generate a new binary ULID at the provided epoch time and write it to the provided buffer.
+*/
+void _cpp_ulid_at_time_bytes(double epoch_time, uint8_t dst[16]) {
   ulid::ULID ulid;
   ulid::EncodeTimestamp(static_cast<int64_t>(epoch_time*1000), ulid);
   ulid::EncodeEntropyRand(ulid);
-  return ulid::MarshalBinary(ulid);
+  ulid::MarshalBinaryTo(ulid, dst);
 }
 
-std::string _cpp_ulid_to_bytes(const char * ulid_string) {
+/**
+* Convert a text ULID to a binary ULID.
+* The buffer passed in must contain at least 26 bytes.
+* Invalid data will result in undefined behavior.
+*/
+void _cpp_ulid_to_bytes(const char * ulid_string, uint8_t dst[16]) {
   ulid::ULID ulid;
   ulid::UnmarshalFrom(ulid_string, ulid);
-  std::vector<uint8_t> data = ulid::MarshalBinary(ulid);
-  std::string str(reinterpret_cast<char *>(data.data()), data.size());
-  return str;
+  ulid::MarshalBinaryTo(ulid, dst);
 }
 
-std::string _cpp_bytes_to_ulid(std::string bytes_string) {
-  std::vector<uint8_t> data(bytes_string.begin(), bytes_string.end());
-  ulid::ULID ulid = ulid::UnmarshalBinary(data);
-  return ulid::Marshal(ulid);
+/**
+* Convert a binary ULID to a text ULID.
+* The buffer passed in must contain at least 16 bytes.
+* The output buffer will NOT be null-terminated.
+*/
+void _cpp_bytes_to_ulid(const uint8_t b[16], char dst[26]) {
+  ulid::ULID ulid;
+  ulid::UnmarshalBinaryFrom(b, ulid);
+  ulid::MarshalTo(ulid, dst);
+}
+
+/**
+* Convert a buffer of exactly 16 bytes to 32 hex characters.
+* The output buffer will NOT be null-terminated.
+*/
+void _cpp_hexlify_16(const uint8_t b[16], char dst[32]) {
+    static const char hexdigits[17] = "0123456789abcdef";
+    int in_index, out_index;
+    for (in_index = out_index = 0; in_index < 16; in_index++) {
+        uint8_t c = b[in_index];
+        dst[out_index++] = hexdigits[c >> 4];
+        dst[out_index++] = hexdigits[c & 0x0f];
+    }
 }

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -78,3 +78,17 @@ void _cpp_hexlify_16(const uint8_t b[16], char dst[32]) {
         dst[out_index++] = hexdigits[c & 0x0f];
     }
 }
+
+/**
+* Interpret the first 6 bytes of a binary ULID as a timestamp.
+*/
+uint64_t _cpp_bytes_to_timestamp(const uint8_t b[16]) {
+    uint64_t timestamp = 0;
+    timestamp |= static_cast<uint64_t>(b[0]) << 40;
+    timestamp |= static_cast<uint64_t>(b[1]) << 32;
+    timestamp |= static_cast<uint64_t>(b[2]) << 24;
+    timestamp |= static_cast<uint64_t>(b[3]) << 16;
+    timestamp |= static_cast<uint64_t>(b[4]) << 8;
+    timestamp |= static_cast<uint64_t>(b[5]);
+    return timestamp;
+}

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -1,15 +1,13 @@
-#include <cstdint>
-#include <string>
-#include <vector>
-
 #ifndef ULID_WRAPPER_H
 #define ULID_WRAPPER_H
+#include <stdint.h>
 
-std::string _cpp_ulid();
-std::vector<uint8_t> _cpp_ulid_bytes();
-std::string _cpp_ulid_at_time(double timestamp);
-std::vector<uint8_t> _cpp_ulid_at_time_bytes(double timestamp);
-std::string _cpp_ulid_to_bytes(const char * ulid_string);
-std::string _cpp_bytes_to_ulid(std::string bytes_string);
+void _cpp_ulid(char dst[26]);
+void _cpp_ulid_bytes(uint8_t dst[16]);
+void _cpp_ulid_at_time(double epoch_time, char dst[26]);
+void _cpp_ulid_at_time_bytes(double epoch_time, uint8_t dst[16]);
+void _cpp_ulid_to_bytes(const char * ulid_string, uint8_t dst[16]);
+void _cpp_bytes_to_ulid(const uint8_t b[16], char dst[26]);
+void _cpp_hexlify_16(const uint8_t b[16], char dst[32]);
 
 #endif

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -9,5 +9,5 @@ void _cpp_ulid_at_time_bytes(double epoch_time, uint8_t dst[16]);
 void _cpp_ulid_to_bytes(const char * ulid_string, uint8_t dst[16]);
 void _cpp_bytes_to_ulid(const uint8_t b[16], char dst[26]);
 void _cpp_hexlify_16(const uint8_t b[16], char dst[32]);
-
+uint64_t _cpp_bytes_to_timestamp(const uint8_t b[16]);
 #endif

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,14 +6,14 @@ import pytest
 def test_ulid_now(impl):
     ulid_str = impl.ulid_now()
     assert len(ulid_str) == 26
-    timestamp = _ulid_timestamp(ulid_str)
+    timestamp = impl.ulid_to_timestamp(ulid_str)
     assert timestamp == pytest.approx(int(time.time() * 1000), 1)
 
 
 def test_ulid_now_bytes(impl):
     ulid_bytes = impl.ulid_now_bytes()
     assert len(ulid_bytes) == 16
-    timestamp = _ulid_timestamp(ulid_bytes)
+    timestamp = impl.ulid_to_timestamp(ulid_bytes)
     assert timestamp == pytest.approx(int(time.time() * 1000), 1)
 
 
@@ -80,7 +80,7 @@ def test_timestamp(impl, gen):
     now = time.time()
     ulid = gen(now)
     # ULIDs store time to 3 decimal places compared to python timestamps
-    assert _ulid_timestamp(ulid) == int(now * 1000)
+    assert impl.ulid_to_timestamp(ulid) == int(now * 1000)
 
 
 @pytest.mark.parametrize("gen", ["ulid_at_time", "ulid_at_time_bytes"])
@@ -89,17 +89,7 @@ def test_timestamp_fixed(impl, gen):
     now = 1677627631.2127638
     ulid = gen(now)
     # ULIDs store time to 3 decimal places compared to python timestamps
-    assert _ulid_timestamp(ulid) == int(now * 1000)
-
-
-def _ulid_timestamp(ulid: str | bytes) -> int:
-    if not isinstance(ulid, bytes):
-        from ulid_transform import ulid_to_bytes
-
-        ulid_bytes = ulid_to_bytes(ulid)
-    else:
-        ulid_bytes = ulid
-    return int.from_bytes(b"\x00\x00" + ulid_bytes[:6], "big")
+    assert impl.ulid_to_timestamp(ulid) == int(now * 1000)
 
 
 def test_non_uppercase_b32_data(impl):


### PR DESCRIPTION
This PR:

* improves the performance of the C implementation by eschewing C++ `std::string` allocations in favor of simple byte buffers and trying to make sure the Cython code does as little copying and unnecessary non-ASCII decoding as possible.
* lifts the "get timestamp" function from the tests to a public API and adds a C implementation for it.

---

> [!CAUTION]
> I tried to be extra fastidious and careful about the use of raw buffers here, but it's likely a good idea to look over this with a pretty fine comb.

---

On my machine, this seems to improve performance approximately thus:

* `ulid_now_bytes`: 1,439 OPS -> 1,757 OPS (+22%)
* `ulid_hex`: 1,057 OPS -> 1,414 OPS (+33%)
* `ut_decode`: 8,862 OPS -> 12,660 OPS (+42%)
* `ulid_at_time`: 5,879 OPS -> 6,390 OPS (+9%)
* `ulid_now`: 5,972 -> 6,189 OPS (+3%)

The new timestamp parsing API is also pretty snappy:

```
--------------------- benchmark 'timestamp': 4 tests ---------------------
Name (time in ns)                   Mean            OPS (Kops/s)
--------------------------------------------------------------------------
test_ut_timestamp[c]             81.4350 (1.0)       12,279.7339 (1.0)
test_ut_timestamp[python]     1,855.7862 (22.79)        538.8552 (0.04)
test_ulidpy_uuid              2,843.5127 (34.92)        351.6777 (0.03)
test_ulid2_timestamp          3,261.0542 (40.04)        306.6493 (0.02)
--------------------------------------------------------------------------
```