### PR TITLE
chore: CI fixes (version upgrades, repair extension build in some configs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
   # Make sure commit messages follow the conventional commits convention:
   # https://www.conventionalcommits.org
@@ -26,7 +26,7 @@ jobs:
     name: Lint Commit Messages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5.3.1
@@ -48,9 +48,9 @@ jobs:
           - "use_cython"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1.3.3
@@ -71,7 +71,7 @@ jobs:
         env:
           REQUIRE_CYTHON: ${{ matrix.extension == 'use_cython' }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -79,7 +79,7 @@ jobs:
     name: "Test on 32-bit Alpine Linux"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Alpine Linux v3.18 for x86
         uses: jirutka/setup-alpine@v1
         with:
@@ -108,9 +108,9 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: snok/install-poetry@v1.3.3
@@ -138,7 +138,7 @@ jobs:
       - commitlint
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -167,14 +167,14 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: "main"
 
       # Used to host cibuildwheel
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -189,7 +189,7 @@ jobs:
         run: |
           echo "::set-output name=newest_release_tag::$(semantic-release print-version --current)"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "v${{ steps.release_tag.outputs.newest_release_tag }}"
           fetch-depth: 0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,9 +11,9 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Install labels

--- a/src/ulid_transform/ulid_wrapper.h
+++ b/src/ulid_transform/ulid_wrapper.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This PR:

* upgrades various CI actions so GHA doesn't complain about Node.js versions as much
* fixes the missing `include` that caused some wheels not to be built.
