### PR TITLE
perf(build): parallelize C extension compilation

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -34,6 +34,8 @@ ulid_module = Extension(
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
+        if self.parallel is None:  # type: ignore[has-type]
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
         except Exception:  # nosec

--- a/build_ext.py
+++ b/build_ext.py
@@ -34,7 +34,7 @@ ulid_module = Extension(
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
-        if self.parallel is None:  # type: ignore[has-type]
+        if self.parallel is None:
             self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()

--- a/build_ext.py
+++ b/build_ext.py
@@ -34,7 +34,7 @@ ulid_module = Extension(
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
-        if self.parallel is None:
+        if self.parallel is None:  # type: ignore[has-type, unused-ignore]
             self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()


### PR DESCRIPTION
## Summary

Default `BuildExt.parallel` to `os.cpu_count()` so per module compilations run in parallel instead of one at a time; mirrors esphome/aioesphomeapi#1662, Bluetooth-Devices/habluetooth#421, and python-zeroconf/python-zeroconf#1689.

## Test plan

- [x] Pre-commit hooks pass locally (ruff, mypy, codespell, prettier)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Build process now automatically enables parallel execution by default, utilizing available CPU cores to accelerate compilation times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bluetooth-Devices/ulid-transform/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->