### PR TITLE
ci: use astral setup-uv to provision Python and poetry for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,22 @@ jobs:
             os: windows-latest
             extension: "use_extension"
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
+      - name: Cache poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         # the separate `pip install` phase is required because Poetry
         # appears to hide the output of `pip install` commands (and possibly
@@ -116,13 +124,22 @@ jobs:
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
+      - name: Cache poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-benchmark-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         run: poetry install --only=main,dev,benchmark
         env:
@@ -140,11 +157,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Setup Python 3.13
         uses: actions/setup-python@v6
         with:
           python-version: 3.13
-      - uses: snok/install-poetry@v1.4.1
+          cache: "poetry"
       - name: Install Dependencies
         run: |
           REQUIRE_EXTENSION=1 poetry install --only=main,dev


### PR DESCRIPTION
## What

Swap the test, benchmark, and codspeed jobs from `actions/setup-python` plus `snok/install-poetry` over to `astral-sh/setup-uv`, which provisions Python and poetry.

## Why

uv is faster and brings a shared download cache, so warm runs skip the Python install entirely; it also matches the pattern already used in the sibling repos, so the CI shape stays consistent.

## How

Each test runner now sets up uv with `enable-cache: true` and the matrix's `python-version`, then installs poetry via `uv tool install poetry`; the codspeed job keeps `actions/setup-python` with `cache: poetry` so the venv is keyed off `poetry.lock`. The rest of each job (poetry install, pytest, codspeed) is unchanged.

## Testing

Workflow change only, will be exercised by CI on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure to improve build efficiency and caching mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bluetooth-Devices/ulid-transform/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->