### PR TITLE
ci: build armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,45 +247,45 @@ jobs:
             musl: "musllinux"
           # qemu is slow, make a single
           # runner per Python version
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp311
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp312
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp313
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp314
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp314t
           # qemu is slow, make a single
           # runner per Python version
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp311
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp312
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp313
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp314
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp314t


### PR DESCRIPTION
Move the armv7l wheel builds off ubuntu-latest plus QEMU and onto ubuntu-24.04-arm; QEMU still provides the 32 bit ARM binfmt handler, but running on an aarch64 host is much cheaper than emulating aarch64 on x86_64.

Ports https://github.com/python-zeroconf/python-zeroconf/pull/1741, which itself ports https://github.com/aio-libs/yarl/pull/1724.