### PR TITLE
ci: key venv cache on resolved python patch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
+        id: setup-uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
@@ -71,7 +72,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock') }}
+          key: poetry-${{ runner.os }}-${{ steps.setup-uv.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         # the separate `pip install` phase is required because Poetry
         # appears to hide the output of `pip install` commands (and possibly
@@ -129,6 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
+        id: setup-uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
@@ -139,7 +141,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-benchmark-${{ hashFiles('poetry.lock') }}
+          key: poetry-${{ runner.os }}-${{ steps.setup-uv.outputs.python-version }}-benchmark-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         run: poetry install --only=main,dev,benchmark
         env:


### PR DESCRIPTION
## Summary
Keys the venv cache on the Python version that the setup step actually resolved instead of the matrix minor version, so a patch upgrade on the runner invalidates the cache instead of silently reusing stale built artifacts.

## Details
The cache key previously used `matrix.python-version`, which is just the minor version like 3.13, so a patch upgrade on the runner kept the old cache around; switching to the resolved `python-version` output pins the cache to the exact patch version that was actually installed.

## Test plan
- [ ] CI passes on this branch.
