### PR TITLE
ci: retry setup-alpine when apk.static download times out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Alpine Linux v3.22 for x86
+        id: setup-alpine
+        continue-on-error: true
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: x86
+          branch: v3.22
+      - name: Retry Setup Alpine Linux v3.22 for x86
+        if: steps.setup-alpine.outcome == 'failure'
         uses: jirutka/setup-alpine@v1
         with:
           arch: x86


### PR DESCRIPTION
## What

Run `jirutka/setup-alpine` twice when the first attempt fails so a transient `apk.static` download error stops killing the 32-bit Alpine check.

## Why

The action fetches `apk.static` from `gitlab.alpinelinux.org` during setup, and that endpoint has been intermittently returning `curl: (28) SSL connection timeout`; when it does, the 32-bit Alpine job fails before any of our code runs, which is why PR #204 and several other recent PRs hit a red check on this job for reasons unrelated to the change.

## How

The first invocation sets `continue-on-error: true` plus an `id`, then a second identical invocation runs only when `steps.setup-alpine.outcome == 'failure'`. The action does not retry the download itself, and `nick-fields/retry` cannot wrap a `uses:` step, so this two-step pattern is the simplest mitigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD reliability by adding a retry mechanism for Alpine Linux setup during test runs, ensuring more robust build processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bluetooth-Devices/ulid-transform/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->