### PR TITLE
ci: fix release job for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     concurrency:
-      group: release-${{ github.head_ref || github.ref }}
+      group: release-${{ github.ref }}
       cancel-in-progress: false
     permissions:
       id-token: write
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
 
       # Do a dry run of PSR
       - name: Test release


### PR DESCRIPTION
## What

Fix the release job so cross-repo PRs no longer fail at the checkout step.

## Why

For PRs from forks, `github.head_ref` resolves to the source branch name in the fork, which does not exist in the base repo, so the release job's checkout errors with "branch could not be found" (visible on #208). The concurrency group used the same expression, so two forks that happened to share a branch name would have collided.

## How

The checkout step now uses `github.event.pull_request.head.sha` on PR events, falling back to `github.ref_name` on push events, which works for both fork and same-repo PRs. The concurrency group keys on `github.ref`, which is already unique per PR (`refs/pull/N/merge`) and resolves to `refs/heads/main` on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved CI/CD reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bluetooth-Devices/ulid-transform/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->