### PR TITLE
ci: give PSR a named branch on PR dry runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
 
+      # PSR errors on detached HEAD; give it a named branch for PR dry runs
+      - name: Create local branch for PSR dry run
+        if: github.event_name == 'pull_request'
+        run: git switch -c "pr-${{ github.event.pull_request.number }}"
+
       # Do a dry run of PSR
       - name: Test release
         uses: python-semantic-release/python-semantic-release@v10.5.3


### PR DESCRIPTION
## What

Create a local branch after checkout so python-semantic-release does not see a detached HEAD on PR dry runs.

## Why

#214 fixed the checkout step for fork PRs by using `github.event.pull_request.head.sha`, but checking out a SHA leaves the runner in detached HEAD; PSR then exits non-zero with `Detached HEAD state cannot match any release groups`, so the release job still fails on PR #208.

## How

Before the dry run, add a step that runs only on `pull_request` events and creates a local branch named `pr-N` from the checked out SHA. PSR now evaluates a branch name, and since `pr-N` does not match any release group in `pyproject.toml`, it no-ops cleanly. The main branch path is untouched, so real releases keep working.