### PR TITLE
ci: scope release env and OIDC permissions to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,35 @@ jobs:
           run: poetry run pytest --no-cov -vvvvv --codspeed tests/benchmarks
           mode: instrumentation
 
+  # Dry run on PRs and non-main pushes. No environment, no publish
+  # permissions, no OIDC, so PR runs carry no release blast radius.
+  release-dry-run:
+    needs:
+      - test
+      - lint
+      - test32bit
+      - commitlint
+      - sdist_safe_path
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          no_operation_mode: true
+
+  # Real release, only on main. The release environment and write/OIDC
+  # permissions are scoped to this job so they never apply to PR runs.
   release:
     needs:
       - test
@@ -219,7 +248,7 @@ jobs:
       - test32bit
       - commitlint
       - sdist_safe_path
-
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     environment: release
     concurrency:
@@ -238,23 +267,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
 
-      # PSR errors on detached HEAD; give it a named branch for PR dry runs
-      - name: Create local branch for PSR dry run
-        if: github.event_name == 'pull_request'
-        run: git switch -c "pr-${{ github.event.pull_request.number }}"
-
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@v10.5.3
-        if: github.ref_name != 'main'
-        with:
-          no_operation_mode: true
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: git switch -C "$BRANCH"
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The release job held id-token: write, contents: write, and the release environment on every trigger including pull requests, even though it only published on main; this splits it into two jobs so PR runs no longer carry release credentials.

## Details

release-dry-run runs on PRs and non-main pushes with only contents: read, no environment and no OIDC, just the python-semantic-release dry run; release runs only on main and keeps the release environment plus write and OIDC permissions scoped to that job, so they never apply to untrusted PR code.

## Test plan

- [ ] workflow YAML parses clean
- [ ] dry-run job runs on this PR, publish job stays skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured release workflow to separate validation from production publishing. Release validation now runs independently on non-main branches with minimal permissions. Production releases execute exclusively on the main branch with appropriate publishing permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->